### PR TITLE
Prevent headless from being level 0

### DIFF
--- a/FikaServer/Services/Headless/HeadlessService.cs
+++ b/FikaServer/Services/Headless/HeadlessService.cs
@@ -145,7 +145,7 @@ public class HeadlessService(ISptLogger<HeadlessService> logger,
             baseHeadlessLevel += profile.CharacterData.PmcData.Info.Level ?? 1;
         }
 
-        baseHeadlessLevel /= players;
+        baseHeadlessLevel = Math.Max(1, baseHeadlessLevel / players);
 
         logger.Log(SPTarkov.Server.Core.Models.Spt.Logging.LogLevel.Debug,
             $"[{headlessClientId}] Settings headless level to: {baseHeadlessLevel} | Players: {players}");


### PR DESCRIPTION
If you start a match with the headless hosting, and a single level 1 PMC (you) the headless will be level 0.
No Pmc should ever be level 0, scavs on the other hand - can be. It would never be expected that a Pmc will be lv0.